### PR TITLE
feat: begin adding allocator & refactor constructor / destructor

### DIFF
--- a/TemplateContainer/ReadMe.md
+++ b/TemplateContainer/ReadMe.md
@@ -32,3 +32,11 @@ The following features are planned to be supported by MyVec:
     size_t capacity：当前分配的数组容量。
 ## License
 This project is licensed under the [MIT License](LICENSE).
+
+
+## References
+
+### Allocator
+- [Why use allocators instead of `new`?](https://stackoverflow.com/questions/5628059/c-stl-allocator-vs-operator-new)
+- [`allocator_traits`: accessing various properties of the allocator class](https://en.cppreference.com/w/cpp/memory/allocator_traits)
+- [allocator interface](https://en.cppreference.com/w/cpp/memory/allocator)

--- a/TemplateContainer/myvec.hpp
+++ b/TemplateContainer/myvec.hpp
@@ -3,26 +3,114 @@
 
 #include <vector> // For debugging usage
 #include <iostream>
+#include <memory>
 
-template <typename T>
+template <typename T, typename Allocator = std::allocator<T>>
 class MyVec
 {
 private:
-  T *data = nullptr;
-  size_t data_size = 0;
-  size_t data_length = 0;
-  std::vector<T> debug_data = std::vector<T>();
+  using size_type = std::size_t;
+  using traits = std::allocator_traits<Allocator>;
+
+  Allocator m_allocator { Allocator() };
+  size_type m_capacity { 0 };
+  size_type m_size { 0 };
+  T* m_data { nullptr };
 
 public:
-  // constructor
-  MyVec();
-  // MyVec(size_t size);
-  // MyVec(size_t size, const T &value);
-  // MyVec(const MyVec &rhs);
-  // MyVec(MyVec &&rhs);
-  // desctructor
-  ~MyVec();
-  // void clear();
+
+  /**
+   * @brief Constructs a new MyVec object.
+   *
+   * @param alloc The allocator object to be used for memory allocation.
+   */
+  explicit MyVec(const Allocator &alloc = Allocator())
+
+    : m_allocator(alloc)
+    , m_capacity(0)
+    , m_size(0)
+    , m_data(nullptr)
+  {
+    m_data = m_allocator.allocate(m_capacity);
+  }
+
+  /**
+   * @brief Constructs a `MyVec` object with a specified size and initial value.
+   *
+   * @param count The number of elements to construct.
+   * @param value The value to initialize the elements with (default is a default-constructed value of type `T`).
+   * @param alloc The allocator object to use (default is the default allocator for type `T`).
+   */
+  explicit MyVec(size_type count, const T& value = T(), const Allocator& alloc = Allocator())
+    : m_allocator(alloc)
+    , m_capacity(count)
+    , m_size(count)
+    , m_data(nullptr)
+  {
+    m_data = m_allocator.allocate(m_capacity);
+    for (size_type i = 0; i < count; ++i) {
+      construct_at(m_data + i, value);
+    }
+  }
+
+  /**
+   * @brief Copy constructor of MyVec
+   *
+   * @param other the container to copy the contents from.
+   */
+  MyVec(const MyVec& other)
+    : m_allocator(other.m_allocator)
+    , m_capacity(other.m_size)
+    , m_size(other.m_size)
+    , m_data(nullptr)
+  {
+    m_data = m_allocator.allocate(m_capacity);
+    for (size_type i = 0; i < m_size; ++i) {
+      construct_at(m_data + i, other.m_data[i]);
+    }
+  }
+
+  /**
+   * @brief Move constructor of MyVec
+   *
+   * @param other the container to move the contents from. After the move operation, `other` is guaranteed to be empty.
+   */
+  MyVec(MyVec&& other)
+    : m_allocator(other.m_allocator)
+    , m_capacity(other.m_capacity)
+    , m_size(other.m_size)
+    , m_data(other.m_data)
+  {
+    other.m_capacity = 0;
+    other.m_size = 0;
+    other.m_data = nullptr;
+  }
+
+  /**
+   * @brief Destructor for the MyVec class.
+   *
+   * This destructor clears the container and deallocates the memory used by the container.
+   */
+  ~MyVec()
+  {
+    clear();
+    m_allocator.deallocate(m_data, m_capacity);
+  }
+
+
+  /**
+   * @brief Erases all elements from this container. After this call, size of this container should be zero.
+   *
+   * Note: this method keeps the container capacity unchanged.
+   */
+  void clear()
+  {
+    for(size_type i = 0; i < m_size; ++i) {
+      traits::destroy(m_allocator, m_data + i);
+    }
+    m_size = 0;
+  }
+
   // void resize();
   // void push_back();
   // void pop_back();
@@ -35,31 +123,6 @@ public:
   // T &at(size_t index) const;
 };
 
-#include "myvec.hpp"
-
-template <typename T>
-MyVec<T>::MyVec()
-{
-  std::cout << "MyVec constructor" << std::endl;
-  data_size = 0;
-  data_length = 0;
-  if (data != nullptr)
-  {
-    delete[] data;
-    data = nullptr;
-  }
-};
-template <typename T>
-MyVec<T>::~MyVec()
-{
-  std::cout << "MyVec destructor" << std::endl;
-  if (data != nullptr)
-  {
-    delete[] data;
-  }
-};
-
-template class MyVec<int>;
 #endif // MYVEC_HPP
 // template class MyVec<float>;
 // template class MyVec<double>;


### PR DESCRIPTION
# Why

Allocators is a useful class and a standard way in STL constructors to allow fine-grained memory control. This PR aims to utilize them for the constructors / destructors.